### PR TITLE
Change stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.3
+- Fix stability in module.xml
+
 # 0.3.2
 - Missing domain name for some translations ([#7](https://github.com/thelia-modules/BackOfficePath/pull/7))
 

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,12 +7,12 @@
     <descriptive locale="fr_FR">
         <title>Chemin BackOffice</title>
     </descriptive>
-    <version>0.3.2</version>
+    <version>0.3.3</version>
     <author>
         <name>Julien Chanséaume</name>
         <email>jchanseaume@openstudio.fr</email>
     </author>
     <type>classic</type>
     <thelia>2.0.0</thelia>
-    <stability>stable</stability>
+    <stability>prod</stability>
 </module>


### PR DESCRIPTION
Change stability

```
Module BackOfficePath: local/modules/BackOfficePath/Config/module.xml file is not a valid file : XML error "Element 'stability': [facet 'enumeration'] The value 'stable' is not an element of the set {'alpha', 'beta', 'rc', 'prod', 'other'}.
```
